### PR TITLE
Tiny API Ingress

### DIFF
--- a/argocd/application-tiny-api-with-lb-svc.yaml
+++ b/argocd/application-tiny-api-with-lb-svc.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tiny-api
+  namespace: argocd
+  labels:
+    name: tiny-api
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/2beens/tiny-api-k8s.git
+    targetRevision: HEAD
+    path: kubernetes-tiny-api-with-lb-svc
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: tiny-api
+  syncPolicy:
+    automated: # automated sync by default retries failed attempts 5 times with following delays between attempts ( 5s, 10s, 20s, 40s, 80s ); retry controlled using `retry` field.
+      prune: true # Specifies if resources should be pruned during auto-syncing ( false by default ).
+      selfHeal: true # Specifies if partial app sync should be executed when resources are changed only in target Kubernetes cluster and no git change detected ( false by default ).
+      allowEmpty: false # Allows deleting all application resources during automatic syncing ( false by default ).
+    syncOptions:     # Sync options which modifies sync behavior
+    - CreateNamespace=true # Namespace Auto-Creation ensures that namespace specified as the application destination exists in the destination cluster.

--- a/kubernetes-tiny-api-with-lb-svc/deployment.yaml
+++ b/kubernetes-tiny-api-with-lb-svc/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: tiny-api-deployment
+  name: tiny-api-with-lb-svc-deployment
   namespace: tiny-api
   labels:
     app: tiny-api
@@ -35,3 +35,19 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+---
+# make the tiny api accessible from the outside
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: tiny-api
+  name: tiny-api-with-lb-svc-service
+spec:
+  selector:
+    app: tiny-api
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 9001
+      targetPort: 9001
+      nodePort: 30000

--- a/kubernetes-tiny-api-with-lb-svc/namespace.yaml
+++ b/kubernetes-tiny-api-with-lb-svc/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tiny-api
+  labels:
+    name: tiny-api

--- a/kubernetes-tiny-api/README.md
+++ b/kubernetes-tiny-api/README.md
@@ -1,0 +1,16 @@
+## Tiny API with Ingress
+
+In order to use this, ingress controller has to be added first (via helm):
+
+```sh
+# first need to add Nginx Ingress Controller repository to Helm by running:
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+
+# update to let Helm know what it contains:
+helm repo update
+
+# finally, run the following command to install the Nginx ingress:
+helm install nginx-ingress ingress-nginx/ingress-nginx --set controller.publishService.enabled=true
+```
+
+More info can be found in a small DigitalOcean tutorial: [How To Set Up an Nginx Ingress on DigitalOcean Kubernetes Using Helm](https://www.digitalocean.com/community/tutorials/how-to-set-up-an-nginx-ingress-on-digitalocean-kubernetes-using-helm)

--- a/kubernetes-tiny-api/ingress.yaml
+++ b/kubernetes-tiny-api/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tiny-api-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+  - host: "tiny.api.lb.2beens.xyz"
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: tiny-api-clusterip-service
+            port:
+              number: 80

--- a/kubernetes-tiny-api/service.yaml
+++ b/kubernetes-tiny-api/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tiny-api-clusterip-service
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 9001
+  selector:
+    app: tiny-api


### PR DESCRIPTION
Now that I am experimenting with managed k8s on DigitalOcean, a lot of stuff are simplified there, like e.g. Load Balancers, and it's much easier to use Ingress there.

This PR adds manifests for deploying the tiny api with ingress controller.

The old one (with LB service only) is moved to folder `./kubernetes-tiny-api-with-lb-svc`.