### PR TITLE
TLS for ingress via letsencrypt

### DIFF
--- a/kubernetes-tiny-api/cluster_issuer.yaml
+++ b/kubernetes-tiny-api/cluster_issuer.yaml
@@ -1,0 +1,17 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-issuer
+spec:
+  acme:
+    # email address used for ACME registration
+    email: stubin87@gmail.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      # name of a secret used to store the ACME account private key
+      name: letsencrypt-issuer-private-key
+    # add a single challenge solver, HTTP01 using nginx
+    solvers:
+    - http01:
+        ingress:
+          class: nginx

--- a/kubernetes-tiny-api/ingress.yaml
+++ b/kubernetes-tiny-api/ingress.yaml
@@ -4,7 +4,13 @@ metadata:
   name: tiny-api-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-issuer
 spec:
+  tls:
+  - hosts:
+    - tiny.api.lb.serj-tubin.com
+    - tiny.api.lb.2beens.xyz
+    secretName: tiny-api-tls
   rules:
   - host: "tiny.api.lb.serj-tubin.com"
     http:


### PR DESCRIPTION
Followed [this](https://www.digitalocean.com/community/tutorials/how-to-set-up-an-nginx-ingress-on-digitalocean-kubernetes-using-helm#step-4-securing-the-ingress-using-cert-manager) DigitalOcean guide.